### PR TITLE
Add core logic and CLI workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+packages/*/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # ai-ecommerce
+
+This monorepo contains reusable e-commerce logic and a CLI.
+
+## Packages
+
+- `@ai-ecommerce/core` – cart and checkout utilities
+- `ai-ecommerce` – command line interface
+
+## Usage
+
+Build packages:
+
+```bash
+npm install
+npm run build
+```
+
+Initialize a new project:
+
+```bash
+npx ai-ecommerce init
+```
+
+Add a component:
+
+```bash
+npx ai-ecommerce add component MyComponent
+```
+
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ai-ecommerce-monorepo",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build -w @ai-ecommerce/core && npm run build -w ai-ecommerce"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.3",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "commander": "^14.0.0"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai-ecommerce",
+  "version": "1.0.0",
+  "bin": {
+    "ai-ecommerce": "dist/index.js"
+  },
+  "dependencies": {
+    "@ai-ecommerce/core": "1.0.0",
+    "commander": "^10.0.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,54 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+
+const program = new Command();
+
+program
+  .name('ai-ecommerce')
+  .description('CLI for ai-ecommerce')
+  .version('1.0.0');
+
+program
+  .command('init')
+  .description('Bootstrap a new e-commerce project')
+  .action(() => {
+    const dirs = ['src', 'src/components', 'src/pages'];
+    dirs.forEach(d => fs.mkdirSync(d, { recursive: true }));
+    if (!fs.existsSync('package.json')) {
+      const pkg = {
+        name: 'ecommerce-app',
+        version: '1.0.0',
+        private: true,
+        dependencies: {
+          '@ai-ecommerce/core': 'workspace:*'
+        }
+      };
+      fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+    }
+    if (!fs.existsSync('src/index.ts')) {
+      fs.writeFileSync('src/index.ts', "console.log('Hello ai-ecommerce');\n");
+    }
+    console.log('Project initialized.');
+  });
+
+program
+  .command('add <type> <name>')
+  .description('Add a component or other entity')
+  .action((type, name) => {
+    if (type === 'component') {
+      const dir = path.join('src', 'components');
+      fs.mkdirSync(dir, { recursive: true });
+      const file = path.join(dir, `${name}.ts`);
+      if (!fs.existsSync(file)) {
+        fs.writeFileSync(file, `export const ${name} = () => {\n  // TODO: implement\n};\n`);
+        console.log(`Component ${name} created.`);
+      } else {
+        console.log(`Component ${name} already exists.`);
+      }
+    } else {
+      console.log(`Unknown type ${type}`);
+    }
+  });
+
+program.parse(process.argv);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@ai-ecommerce/core",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,40 @@
+export interface Product {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export interface CartItem {
+  product: Product;
+  quantity: number;
+}
+
+export class Cart {
+  private items: CartItem[] = [];
+
+  addProduct(product: Product, quantity = 1): void {
+    const existing = this.items.find(i => i.product.id === product.id);
+    if (existing) {
+      existing.quantity += quantity;
+    } else {
+      this.items.push({ product, quantity });
+    }
+  }
+
+  removeProduct(productId: string): void {
+    this.items = this.items.filter(i => i.product.id !== productId);
+  }
+
+  getTotal(): number {
+    return this.items.reduce((sum, item) => sum + item.product.price * item.quantity, 0);
+  }
+
+  getItems(): CartItem[] {
+    return [...this.items];
+  }
+}
+
+export function checkout(cart: Cart): string {
+  const total = cart.getTotal().toFixed(2);
+  return `Checked out ${cart.getItems().length} items. Total: $${total}`;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up monorepo workspaces
- add `@ai-ecommerce/core` with cart and checkout logic
- add `ai-ecommerce` CLI with `init` and `add` commands
- configure TypeScript settings
- document usage

## Testing
- `npm install`
- `npm run build`
- `node packages/cli/dist/index.js init`
- `node packages/cli/dist/index.js add component TestComponent`


------
https://chatgpt.com/codex/tasks/task_e_68520ef62aa0832f93c1d4ef54823892