### PR TITLE
Implement basic tests and CLI option handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+packages/*/node_modules
+.env
+
+packages/core/prisma/dev.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # ai-ecommerce
+
+This monorepo contains a minimal ecommerce core built with Prisma and an accompanying CLI.
+
+## Packages
+- **core**: exposes a factory to create a Prisma client using a SQLite database by default. Users can override the connection string.
+- **cli**: exposes the `ai-ecommerce` command to add optional modules (`product`, `cart`, `checkout`) to a project.
+
+## Usage
+Install dependencies and run the CLI:
+
+```bash
+npm install
+npx ai-ecommerce --db-url "file:./my.db" add product
+```
+
+Run the included tests:
+
+```bash
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,137 @@
+{
+  "name": "ai-ecommerce",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "node_modules/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
+    "node_modules/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "packages/cli": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "ai-ecommerce": "bin/ai-ecommerce.js"
+      }
+    },
+    "packages/cli/node_modules/commander": {
+      "version": "14.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/core": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@prisma/client": "^6.10.0",
+        "prisma": "^6.10.0"
+      }
+    },
+    "packages/core/node_modules/@prisma/client": {
+      "version": "6.10.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/core/node_modules/@prisma/config": {
+      "version": "6.10.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "packages/core/node_modules/@prisma/debug": {
+      "version": "6.10.0",
+      "license": "Apache-2.0"
+    },
+    "packages/core/node_modules/@prisma/engines": {
+      "version": "6.10.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.0",
+        "@prisma/engines-version": "6.10.0-43.aee10d5a411e4360c6d3445ce4810ca65adbf3e8",
+        "@prisma/fetch-engine": "6.10.0",
+        "@prisma/get-platform": "6.10.0"
+      }
+    },
+    "packages/core/node_modules/@prisma/engines-version": {
+      "version": "6.10.0-43.aee10d5a411e4360c6d3445ce4810ca65adbf3e8",
+      "license": "Apache-2.0"
+    },
+    "packages/core/node_modules/@prisma/fetch-engine": {
+      "version": "6.10.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.0",
+        "@prisma/engines-version": "6.10.0-43.aee10d5a411e4360c6d3445ce4810ca65adbf3e8",
+        "@prisma/get-platform": "6.10.0"
+      }
+    },
+    "packages/core/node_modules/@prisma/get-platform": {
+      "version": "6.10.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.0"
+      }
+    },
+    "packages/core/node_modules/jiti": {
+      "version": "2.4.2",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "packages/core/node_modules/prisma": {
+      "version": "6.10.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.10.0",
+        "@prisma/engines": "6.10.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "test": "npm --workspace packages/core test && npm --workspace packages/cli test"
+  }
+}

--- a/packages/cli/bin/ai-ecommerce.js
+++ b/packages/cli/bin/ai-ecommerce.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const { program } = require('commander')
+const path = require('path')
+const fs = require('fs')
+
+program
+  .name('ai-ecommerce')
+  .description('AI Ecommerce CLI')
+
+program
+  .command('add <component>')
+  .description('Add a component (product, cart, checkout)')
+  .action((component) => {
+    const src = path.join(__dirname, '../templates', component)
+    if (!fs.existsSync(src)) {
+      console.error(`Unknown component: ${component}`)
+      process.exit(1)
+    }
+    const dest = process.cwd()
+    fs.readdirSync(src).forEach(file => {
+      const srcPath = path.join(src, file)
+      const destPath = path.join(dest, file)
+      if (fs.existsSync(destPath)) return
+      fs.copyFileSync(srcPath, destPath)
+    })
+    console.log(`Added ${component} component`)
+  })
+
+program
+  .option('--db-url <url>', 'database connection string')
+
+program.hook('preAction', (thisCommand) => {
+  const opts = thisCommand.opts()
+  if (opts.dbUrl) {
+    process.env.DATABASE_URL = opts.dbUrl
+  }
+})
+
+program.parse(process.argv)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ai-ecommerce",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/add.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "commander": "^14.0.0"
+  },
+  "bin": {
+    "ai-ecommerce": "bin/ai-ecommerce.js"
+  }
+}

--- a/packages/cli/templates/cart/index.js
+++ b/packages/cli/templates/cart/index.js
@@ -1,0 +1,1 @@
+module.exports = function(){ console.log('Cart module installed') }

--- a/packages/cli/templates/checkout/index.js
+++ b/packages/cli/templates/checkout/index.js
@@ -1,0 +1,1 @@
+module.exports = function(){ console.log('Checkout module installed') }

--- a/packages/cli/templates/product/index.js
+++ b/packages/cli/templates/product/index.js
@@ -1,0 +1,1 @@
+module.exports = function(){ console.log('Product module installed') }

--- a/packages/cli/test/add.test.js
+++ b/packages/cli/test/add.test.js
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-ecom-'));
+execSync(`node ${path.join(__dirname, '../bin/ai-ecommerce.js')} add product`, { cwd: tmp });
+if (!fs.existsSync(path.join(tmp, 'index.js'))) {
+  throw new Error('file not copied');
+}
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('cli test passed');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "core",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "node test/index.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@prisma/client": "^6.10.0",
+    "prisma": "^6.10.0"
+  }
+}

--- a/packages/core/prisma/.env.example
+++ b/packages/core/prisma/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/packages/core/prisma/schema.prisma
+++ b/packages/core/prisma/schema.prisma
@@ -1,0 +1,22 @@
+ datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+ }
+
+ generator client {
+  provider = "prisma-client-js"
+ }
+
+ model Product {
+  id    Int    @id @default(autoincrement())
+  name  String
+  price Float
+ }
+
+ model Order {
+  id        Int      @id @default(autoincrement())
+  product   Product  @relation(fields: [productId], references: [id])
+  productId Int
+  quantity  Int
+  createdAt DateTime @default(now())
+ }

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,0 +1,10 @@
+const { PrismaClient } = require('@prisma/client')
+const path = require('path')
+
+function createClient(options = {}) {
+  const databaseUrl = options.databaseUrl || process.env.DATABASE_URL || `file:${path.join(__dirname, '../prisma/dev.db')}`
+  process.env.DATABASE_URL = databaseUrl
+  return new PrismaClient()
+}
+
+module.exports = { createClient }

--- a/packages/core/test/index.test.js
+++ b/packages/core/test/index.test.js
@@ -1,0 +1,4 @@
+const assert = require('assert');
+const { createClient } = require('../src');
+assert.strictEqual(typeof createClient, 'function');
+console.log('core test passed');


### PR DESCRIPTION
## Summary
- allow `--db-url` option to be processed before commands
- ignore default SQLite database
- add simple tests for core and CLI
- document running tests

## Testing
- `npm test`
- `node packages/cli/bin/ai-ecommerce.js add checkout`

------
https://chatgpt.com/codex/tasks/task_e_68520f029218832f91c90212a84acffc