### PR TITLE
Refactor CLI to use 'modules' folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Initialize a new project:
 npx ai-ecommerce init
 ```
 
-Add a component:
+Add a module:
 
 ```bash
-npx ai-ecommerce add component MyComponent
+npx ai-ecommerce add module MyModule
 ```
 
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,7 +13,7 @@ program
   .command('init')
   .description('Bootstrap a new e-commerce project')
   .action(() => {
-    const dirs = ['src', 'src/components', 'src/pages'];
+    const dirs = ['src', 'src/modules', 'src/pages'];
     dirs.forEach(d => fs.mkdirSync(d, { recursive: true }));
     if (!fs.existsSync('package.json')) {
       const pkg = {
@@ -34,17 +34,17 @@ program
 
 program
   .command('add <type> <name>')
-  .description('Add a component or other entity')
+  .description('Add a module or other entity')
   .action((type, name) => {
-    if (type === 'component') {
-      const dir = path.join('src', 'components');
+    if (type === 'module') {
+      const dir = path.join('src', 'modules');
       fs.mkdirSync(dir, { recursive: true });
       const file = path.join(dir, `${name}.ts`);
       if (!fs.existsSync(file)) {
         fs.writeFileSync(file, `export const ${name} = () => {\n  // TODO: implement\n};\n`);
-        console.log(`Component ${name} created.`);
+        console.log(`Module ${name} created.`);
       } else {
-        console.log(`Component ${name} already exists.`);
+        console.log(`Module ${name} already exists.`);
       }
     } else {
       console.log(`Unknown type ${type}`);


### PR DESCRIPTION
## Summary
- rename `components` directory to `modules`
- update `add` command to create modules
- update README to reflect new naming

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685211db8fa8832f9e9b94b30d1e6feb