### PR TITLE
Add configurable pricing and cart options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,62 @@ Initialize a new project:
 npx ai-ecommerce init
 ```
 
-Add a component:
+Add a module:
 
 ```bash
-npx ai-ecommerce add component MyComponent
+npx ai-ecommerce add module MyModule
 ```
 
+
+### Custom product attributes
+
+The `Product` interface in `@ai-ecommerce/core` accepts a generic parameter
+for custom attributes. This lets you add fields such as `salePrice` or
+color without changing the library:
+
+```ts
+import { Product } from '@ai-ecommerce/core';
+
+interface ShoeAttrs {
+  color: string;
+  salePrice?: number;
+}
+
+const shoe: Product<ShoeAttrs> = {
+  id: 'shoe-1',
+  name: 'Sneaker',
+  price: 79.99,
+  attributes: { color: 'red', salePrice: 59.99 }
+};
+```
+
+### Dynamic pricing and cart options
+
+`Cart` now accepts configuration hooks that let you decide how a product's
+price is determined and whether items can be mixed in the cart. The default
+behaviour uses the `price` field, but you can pick any attribute:
+
+```ts
+import { Cart, Product } from '@ai-ecommerce/core';
+
+interface ShoeAttrs { color: string; salePrice?: number }
+
+const shoe: Product<ShoeAttrs> = {
+  id: 'shoe-1',
+  name: 'Sneaker',
+  price: 79.99,
+  attributes: { color: 'red', salePrice: 59.99 }
+};
+
+const cart = new Cart<ShoeAttrs>({
+  getPrice: p => p.attributes?.salePrice ?? p.price,
+  currency: 'USD'
+});
+
+cart.addProduct(shoe);
+console.log(cart.getTotal()); // 59.99
+```
+
+`CartOptions` also exposes hooks for tax calculation, persistence, inventory
+checks and more so you can integrate the library into any workflow.
 

--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ console.log(cart.getTotal()); // 59.99
 
 `CartOptions` also exposes hooks for tax calculation, persistence, inventory
 checks and more so you can integrate the library into any workflow.
-

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,7 +13,7 @@ program
   .command('init')
   .description('Bootstrap a new e-commerce project')
   .action(() => {
-    const dirs = ['src', 'src/components', 'src/pages'];
+    const dirs = ['src', 'src/modules', 'src/pages'];
     dirs.forEach(d => fs.mkdirSync(d, { recursive: true }));
     if (!fs.existsSync('package.json')) {
       const pkg = {
@@ -34,17 +34,17 @@ program
 
 program
   .command('add <type> <name>')
-  .description('Add a component or other entity')
+  .description('Add a module or other entity')
   .action((type, name) => {
-    if (type === 'component') {
-      const dir = path.join('src', 'components');
+    if (type === 'module') {
+      const dir = path.join('src', 'modules');
       fs.mkdirSync(dir, { recursive: true });
       const file = path.join(dir, `${name}.ts`);
       if (!fs.existsSync(file)) {
         fs.writeFileSync(file, `export const ${name} = () => {\n  // TODO: implement\n};\n`);
-        console.log(`Component ${name} created.`);
+        console.log(`Module ${name} created.`);
       } else {
-        console.log(`Component ${name} already exists.`);
+        console.log(`Module ${name} already exists.`);
       }
     } else {
       console.log(`Unknown type ${type}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,40 +1,111 @@
-export interface Product {
+export interface Product<
+  A extends Record<string, any> = Record<string, any>,
+  Type extends string = string
+> {
+  /** Unique identifier of the product */
   id: string;
+  /** Display name */
   name: string;
+  /**
+   * Base price of the product. Specific pricing schemes (e.g. discounts)
+   * can be represented via custom attributes.
+   */
   price: number;
+  /** Optional product type/category */
+  type?: Type;
+  /**
+   * Optional custom attributes for storing additional product data.
+   */
+  attributes?: A;
 }
 
-export interface CartItem {
-  product: Product;
+export interface CartItem<
+  A extends Record<string, any> = Record<string, any>,
+  Type extends string = string
+> {
+  product: Product<A, Type>;
   quantity: number;
 }
 
-export class Cart {
-  private items: CartItem[] = [];
+export interface CartOptions<
+  A extends Record<string, any> = Record<string, any>,
+  Type extends string = string
+> {
+  /**
+   * Function to resolve the price of a product. Defaults to using `price`.
+   */
+  getPrice?: (product: Product<A, Type>) => number;
+  /**
+   * Hook to decide if a product can be added. Allows restricting combinations.
+   */
+  allowAdd?: (items: CartItem<A, Type>[], product: Product<A, Type>) => boolean;
+  /** Desired currency code. Used by consumers when formatting totals. */
+  currency?: string;
+  /** Optional tax calculator. Receives subtotal and items. */
+  taxCalculator?: (subtotal: number, items: CartItem<A, Type>[]) => number;
+  /** Optional persistence hook invoked on mutations. */
+  persist?: (items: CartItem<A, Type>[]) => void;
+  /** Inventory manager for stock checks and reservations. */
+  inventoryManager?: {
+    checkStock(productId: string, qty: number): boolean;
+    reserveStock(productId: string, qty: number): void;
+  };
+}
 
-  addProduct(product: Product, quantity = 1): void {
+export class Cart<
+  A extends Record<string, any> = Record<string, any>,
+  Type extends string = string
+> {
+  private items: CartItem<A, Type>[] = [];
+  constructor(private options: CartOptions<A, Type> = {}) {}
+
+  addProduct(product: Product<A, Type>, quantity = 1): void {
+    if (this.options.allowAdd && !this.options.allowAdd(this.items, product)) {
+      return;
+    }
+    if (
+      this.options.inventoryManager &&
+      !this.options.inventoryManager.checkStock(product.id, quantity)
+    ) {
+      return;
+    }
     const existing = this.items.find(i => i.product.id === product.id);
     if (existing) {
       existing.quantity += quantity;
     } else {
       this.items.push({ product, quantity });
     }
+    this.options.persist?.(this.items);
+    this.options.inventoryManager?.reserveStock(product.id, quantity);
   }
 
   removeProduct(productId: string): void {
     this.items = this.items.filter(i => i.product.id !== productId);
+    this.options.persist?.(this.items);
   }
 
   getTotal(): number {
-    return this.items.reduce((sum, item) => sum + item.product.price * item.quantity, 0);
+    const getPrice = this.options.getPrice ?? ((p: Product<A, Type>) => p.price);
+    const subtotal = this.items.reduce(
+      (sum, item) => sum + getPrice(item.product) * item.quantity,
+      0
+    );
+    const tax = this.options.taxCalculator
+      ? this.options.taxCalculator(subtotal, this.items)
+      : 0;
+    return subtotal + tax;
   }
 
-  getItems(): CartItem[] {
+  getItems(): CartItem<A, Type>[] {
     return [...this.items];
   }
 }
 
-export function checkout(cart: Cart): string {
+export function checkout<
+  A extends Record<string, any>,
+  Type extends string
+>(cart: Cart<A, Type>): string {
   const total = cart.getTotal().toFixed(2);
-  return `Checked out ${cart.getItems().length} items. Total: $${total}`;
+  const currency = cart['options']?.currency ?? 'USD';
+  return `Checked out ${cart.getItems().length} items. Total: ${currency} ${total}`;
 }


### PR DESCRIPTION
## Summary
- enable advanced generics for `Product`
- introduce `CartOptions` for dynamic pricing, validation and more
- update `Cart` and `checkout` with new configuration hooks
- document dynamic pricing

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685211db8fa8832f9e9b94b30d1e6feb